### PR TITLE
Babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-preset-env": "^1.7.0",
-    "babel-register": "^6.26.0",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
     "codecov": "^3.0.4",
     "cross-env": "^5.2.0",
     "esdoc": "^1.1.0",
@@ -68,7 +69,7 @@
   "babel": {
     "presets": [
       [
-        "env",
+        "@babel/preset-env",
         {
           "targets": {
             "node": "0.10"


### PR DESCRIPTION
[Babel 7 Released](https://babeljs.io/blog/2018/08/27/7.0.0)
[Upgrade to Babel 7](http://new.babeljs.io/docs/en/next/v7-migration.html)